### PR TITLE
fix promise catch handling

### DIFF
--- a/src/actions/data.js
+++ b/src/actions/data.js
@@ -35,7 +35,9 @@ export function fetchData(resource) {
         dispatch(requestData(resource))
         return fetch(`/api/${resource}`)
             .then(req => req.json())
-            .then(json => dispatch(receiveData(resource, json)))
-            .catch(err => dispatch(receiveDataError(resource, err)))
+            .then(
+                json => dispatch(receiveData(resource, json)),
+                err => dispatch(receiveDataError(resource, err))
+            )
     }
 }


### PR DESCRIPTION
If the request is successful, but an error is thrown in the result of `dispatch(receiveData(resource, json))` which includes the React render pass caused by the any state change dispatch the made, then the error would be thrown and caught, then `dispatch`ed by the `receiveDataError` handler.

This is not what you want, and hides the error in a difficult to debug fashion.
